### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/event10342012/12083d69-cec7-421d-a147-32d25c81f730/2b0c6493-0edc-4be9-a860-6d08ea2778be/_apis/work/boardbadge/75ecb926-f722-4029-b34e-b6874f82ca39)](https://dev.azure.com/event10342012/12083d69-cec7-421d-a147-32d25c81f730/_boards/board/t/2b0c6493-0edc-4be9-a860-6d08ea2778be/Microsoft.RequirementCategory)
 # algorithm-practice
 Practice data structure and algorithm 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#50](https://dev.azure.com/event10342012/12083d69-cec7-421d-a147-32d25c81f730/_workitems/edit/50). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.